### PR TITLE
Add support for custom class regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,16 @@ Headwind ships with a default class order (located in [package.json](package.jso
 
 <img src="https://github.com/heybourn/headwind/blob/master/img/settings.png?raw=true" alt="Settings" width="750px">
 
-## `headwind.sortTailwindClasses`:
+### `headwind.sortTailwindClasses`:
 
-## `headwind.classRegex`:
+A string array that determines the default sort order.
+
+### `headwind.classRegex`:
+
+A string that determines the default regex to search a class attribute.
+The default is set to `\bclass(?:Name)*\s*=\s*([\"\']([_a-zA-Z0-9\s\-\:]+)[\"\'])` but can be customized to fit your needs.
+
+Make sure if a new group is created that this is non-capturing by using `(?:)`.
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Headwind ships with a default class order (located in [package.json](package.jso
 
 <img src="https://github.com/heybourn/headwind/blob/master/img/settings.png?raw=true" alt="Settings" width="750px">
 
+## `headwind.sortTailwindClasses`:
+
+## `headwind.classRegex`:
+
 # Contributing
 
 Headwind is open source and contributions are always welcome. If you're interested in submitting a pull request, please take a moment to review [CONTRIBUTING.md](.github/CONTRIBUTING.md).

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
         "sort",
         "sorter",
         "vscode"
-      ],
+    ],
     "galleryBanner": {
         "color": "#f1f5f8"
-      },
+    },
     "icon": "icon.png",
     "version": "0.0.1",
     "publisher": "heybourn",
@@ -1254,7 +1254,13 @@
                         ],
                         "description": "Sort order: A string array that determines the default sort order.",
                         "scope": "window"
-                    }
+										},
+										"headwind.classRegex": {
+											"type": "string",
+											"default": "\\bclass(?:Name)*\\s*=\\s*([\\\"\\']([_a-zA-Z0-9\\s\\-\\:]+)[\\\"\\'])",
+											"description": "Class regex: A string that determines the default regex to search a class attribute.",
+											"scope": "window"
+										}
                 }
             }
         ]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,7 +5,10 @@ import { commands, workspace, ExtensionContext, Range } from 'vscode';
 import { sortClassString } from './utils';
 
 const sortOrder = workspace.getConfiguration().get('headwind.defaultSortOrder');
-const HTMLClassAtrributeRegex = /\bclass\s*=\s*([\"\']([_a-zA-Z0-9\s\-\:]+)[\"\'])/gi;
+const HTMLClassAtrributeRegex = new RegExp(
+	workspace.getConfiguration().get('headwind.classRegex'),
+	'gi'
+);
 
 export function activate(context: ExtensionContext) {
 	let disposable = commands.registerTextEditorCommand(


### PR DESCRIPTION
This feature request is created for the open issue #4 and allows user to configure a custom regex based on the user requirements.

The default regex `\bclass(?:Name)*\s*=\s*([\"\']([_a-zA-Z0-9\s\-\:]+)[\"\'])` matches the following patterns
- `class`
- `className`

In case a capturing group is used in the regex the user needs to ensure that the group is non-capturing or else a weird behaviour can occur.

This is related to the following snippet:
https://github.com/heybourn/headwind/blob/d77b0fbabd0554ab67871f4bdac2ffd6f5844c45/src/extension.ts#L20-L21