### PR TITLE
Fixed indentation mismatch and typescript error.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1243,13 +1243,13 @@
                         ],
                         "description": "Sort order: A string array that determines the default sort order.",
                         "scope": "window"
-										},
-										"headwind.classRegex": {
-											"type": "string",
-											"default": "\\bclass(?:Name)*\\s*=\\s*([\\\"\\']([_a-zA-Z0-9\\s\\-\\:]+)[\\\"\\'])",
-											"description": "Class regex: A string that determines the default regex to search a class attribute.",
-											"scope": "window"
-										}
+                    },
+                    "headwind.classRegex": {
+                        "type": "string",
+                        "default": "\\bclass(?:Name)*\\s*=\\s*([\\\"\\']([_a-zA-Z0-9\\s\\-\\:]+)[\\\"\\'])",
+                        "description": "Class regex: A string that determines the default regex to search a class attribute.",
+                        "scope": "window"
+                    }
                 }
             }
         ]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,11 +4,11 @@ import { commands, workspace, ExtensionContext, Range } from 'vscode';
 
 import { sortClassString } from './utils';
 
-const sortOrder = workspace.getConfiguration().get('headwind.defaultSortOrder');
-const HTMLClassAtrributeRegex = new RegExp(
-	workspace.getConfiguration().get('headwind.classRegex'),
-	'gi'
-);
+const config = workspace.getConfiguration();
+const configRegex: string = config.get('headwind.classRegex') || '';
+
+const sortOrder = config.get('headwind.defaultSortOrder');
+const HTMLClassAtrributeRegex = new RegExp(configRegex, 'gi');
 
 export function activate(context: ExtensionContext) {
 	let disposable = commands.registerTextEditorCommand(


### PR DESCRIPTION
Fixes typescript error introduced in #7 and also fixes #11
Also transformed tabs to spaces on package.json property `headwind.classRegex`