### PR TITLE
Updated README.md with the new default classRegex

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A string array that determines the default sort order.
 ### `headwind.classRegex`:
 
 A string that determines the default regex to search a class attribute.
-The default is set to `\bclass(?:Name)*\s*=\s*([\"\']([_a-zA-Z0-9\s\-\:]+)[\"\'])` but can be customized to fit your needs.
+The default is set to `\bclass(?:Name)*\\s*=\\s*([\\\"\\']([_a-zA-Z0-9\\s\\-\\:\\/]+)[\\\"\\'])` but can be customized to fit your needs.
 
 Make sure if a new group is created that this is non-capturing by using `(?:)`.
 


### PR DESCRIPTION
README.md included a version of the classRegex that is now outdated. I've updated this to match the current version of Headwind.