### PR TITLE
Adding missing class 'content-around'

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
                             "content-center",
                             "content-end",
                             "content-between",
+                            "content-around",
                             "self-auto",
                             "self-start",
                             "self-center",


### PR DESCRIPTION
Adds missing class "content-around" to the default class list in package.json


.content-around | align-content: space-around;
-- | --


