### PR TITLE
Modify classRegex to be more configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# Headwind 
+# Headwind
 
 [![CircleCI](https://circleci.com/gh/heybourn/headwind.svg?style=svg)](https://circleci.com/gh/heybourn/headwind)
 
-Headwind is an opinionated Tailwind CSS class sorter for Visual Studio Code. It enforces consistent ordering of classes by parsing your code and reprinting class tags to follow a given order. 
+Headwind is an opinionated Tailwind CSS class sorter for Visual Studio Code. It enforces consistent ordering of classes by parsing your code and reprinting class tags to follow a given order.
 
 > Headwind runs on save, will remove duplicate classes and can even sort entire workspaces.
 
 ---
 
-**[Get it from the VS Code Marketplace →](https://marketplace.visualstudio.com/items?itemName=heybourn.headwind)** 
+**[Get it from the VS Code Marketplace →](https://marketplace.visualstudio.com/items?itemName=heybourn.headwind)**
 
 **[Use PHPStorm? Get @WalrusSoup's Headwind port →](https://plugins.jetbrains.com/plugin/13376-tailwind-formatter/)**
 
@@ -16,7 +16,7 @@ Headwind is an opinionated Tailwind CSS class sorter for Visual Studio Code. It 
 
 <img src="https://github.com/heybourn/headwind/blob/master/img/explainer.gif?raw=true" alt="Explainer" width="750px">
 
-# Usage
+## Usage
 
 You can install Headwind via the VS Code Marketplace, or package it yourself using [vsce](https://code.visualstudio.com/api/working-with-extensions/publishing-extension). Headwind works globally once installed and will run on save if a `tailwind.config.js` file is present within your working directory.
 
@@ -29,16 +29,25 @@ Headwind can sort individual files by running 'Sort Tailwind CSS Classes' via th
 
 Any breakpoints or unknown classes will be moved to the end of the class list, whilst duplicate classes will be removed.
 
-# Customisation
+## Customisation
 
 Headwind ships with a default class order (located in [package.json](package.json)). You can edit this (and other settings) to your liking on the extension settings page.
 
 ### `headwind.classRegex`:
 
-A string that determines the default regex to search a class attribute.
-The default value is set to `\bclass(?:Name)*\\s*=\\s*([\\\"\\']([_a-zA-Z0-9\\s\\-\\:\\/]+)[\\\"\\'])` but this can be customized to suit your needs.
+An object with language IDs as keys and their values determining the regex to search for Tailwind CSS classes.
+The default is located in [package.json](package.json) but this can be customized to suit your needs.
 
-If a new group is created, ensure that it is non-capturing by using `(?:)`.
+There can be multiple capturing groups, that should only contain a string with Tailwind CSS classes (without any apostrophies etc.). If a new group, which doesn't contain the `class` string, is created, ensure that it is non-capturing by using `(?:)`.
+
+Example from `package.json`:
+
+```json
+"headwind.classRegex": {
+		"html": "\\bclass\\s*=\\s*[\\\"\\']([_a-zA-Z0-9\\s\\-\\:\\/]+)[\\\"\\']",
+		"javascriptreact": "(?:\\bclassName\\s*=\\s*[\\\"\\']([_a-zA-Z0-9\\s\\-\\:\\/]+)[\\\"\\'])|(?:\\btw\\s*`([_a-zA-Z0-9\\s\\-\\:\\/]*)`)"
+}
+```
 
 ### `headwind.sortTailwindClasses`:
 
@@ -56,6 +65,6 @@ Headwind will run on save by default (if a `tailwind.config.js` file is present 
 
 `"headwind.runOnSave": false`
 
-# Contributing
+## Contributing
 
 Headwind is open source and contributions are always welcome. If you're interested in submitting a pull request, please take a moment to review [CONTRIBUTING.md](.github/CONTRIBUTING.md).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "headwind",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1256,9 +1256,16 @@
                         "scope": "window"
                     },
                     "headwind.classRegex": {
-                        "type": "string",
-                        "default": "\\bclass(?:Name)*\\s*=\\s*([\\\"\\']([_a-zA-Z0-9\\s\\-\\:\\/]+)[\\\"\\'])",
-                        "description": "Class regex: A string that determines the default regex to search a class attribute.",
+                        "type": "object",
+                        "default": {
+                            "html": "\\bclass\\s*=\\s*[\\\"\\']([_a-zA-Z0-9\\s\\-\\:\\/]+)[\\\"\\']",
+                            "css": "\\B@apply\\s+([_a-zA-Z0-9\\s\\-\\:\\/]+);",
+                            "javascript": "(?:\\bclassName\\s*=\\s*[\\\"\\']([_a-zA-Z0-9\\s\\-\\:\\/]+)[\\\"\\'])|(?:\\btw\\s*`([_a-zA-Z0-9\\s\\-\\:\\/]*)`)",
+                            "javascriptreact": "(?:\\bclassName\\s*=\\s*[\\\"\\']([_a-zA-Z0-9\\s\\-\\:\\/]+)[\\\"\\'])|(?:\\btw\\s*`([_a-zA-Z0-9\\s\\-\\:\\/]*)`)",
+                            "typescript": "(?:\\bclassName\\s*=\\s*[\\\"\\']([_a-zA-Z0-9\\s\\-\\:\\/]+)[\\\"\\'])|(?:\\btw\\s*`([_a-zA-Z0-9\\s\\-\\:\\/]*)`)",
+                            "typescriptreact": "(?:\\bclassName\\s*=\\s*[\\\"\\']([_a-zA-Z0-9\\s\\-\\:\\/]+)[\\\"\\'])|(?:\\btw\\s*`([_a-zA-Z0-9\\s\\-\\:\\/]*)`)"
+                        },
+                        "description": "An object with language IDs as keys and their values determining the regex to search for Tailwind CSS classes.",
                         "scope": "window"
                     },
                     "headwind.runOnSave": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "color": "#f1f5f8"
     },
     "icon": "icon.png",
-    "version": "1.6.1",
+    "version": "1.6.2",
     "publisher": "heybourn",
     "license": "MIT",
     "author": "Ryan Heybourn <ryan@heybourn.com>",


### PR DESCRIPTION
Before this change, we used a single `classRegex` string for all possible file types.
This change allows more configurability in the form of different `classRegex`s for different languages. Thanks to this PR using Headwind in a bigger project will be more useful.

Headwind detects the documents `languageId` and uses it's `classRegex` config
for finding the `class` strings.

The `classRegex` config now requires that capture groups contain a `class` string
like `class1 class2 class3` instead of one containing a `class` string with
apostrophies and one without. There can be multiple capture groups which can be used
for example in React applications where we have both `className` attributes and
CSS-in-JS `tw` tagged templates.

In this PR when there's no config for some language Headwind just won't
parse the file. Should this be the default behaviour? Because it can be easily changed to use a default `html` config or show a message.