### PR TITLE
Adding Additional Config to Prepend Custom Classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ Headwind will remove duplicate class names by default. This can be toggled on or
 
 `"headwind.removeDuplicates": false`
 
+### `headwind.prependCustomClasses`:
+
+Headwind will append custom class names by default. They can be prepended instead.
+
+`"headwind.prependCustomClasses": true`
+
 ### `headwind.runOnSave`:
 
 Headwind will run on save by default (if a `tailwind.config.js` file is present within your working directory). This can be toggled on or off.

--- a/package.json
+++ b/package.json
@@ -1279,6 +1279,12 @@
                         "description": "A flag that controls whether or not Headwind will remove duplicate Tailwind CSS classes.",
                         "type": "boolean",
                         "scope": "window"
+                    },
+                    "headwind.prependCustomClasses": {
+                        "default": false,
+                        "description": "A flag that controls whether or not Headwind will move custom CSS classes before (true) or after (false) the Tailwind CSS classes.",
+                        "type": "boolean",
+                        "scope": "window"
                     }
                 }
             }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,6 +18,14 @@ const shouldRemoveDuplicates =
 		? shouldRemoveDuplicatesConfig
 		: true;
 
+const shouldPrependCustomClassesConfig = config.get(
+	'headwind.prependCustomClasses'
+);
+const shouldPrependCustomClasses =
+	typeof shouldPrependCustomClassesConfig === 'boolean'
+		? shouldPrependCustomClassesConfig
+		: false;
+
 export function activate(context: ExtensionContext) {
 	let disposable = commands.registerTextEditorCommand(
 		'headwind.sortTailwindClasses',
@@ -43,12 +51,17 @@ export function activate(context: ExtensionContext) {
 					editor.document.positionAt(endPosition)
 				);
 
+				const options = {
+					shouldRemoveDuplicates,
+					shouldPrependCustomClasses
+				};
+
 				edit.replace(
 					range,
 					sortClassString(
 						valueMatch,
 						Array.isArray(sortOrder) ? sortOrder : [],
-						shouldRemoveDuplicates
+						options
 					)
 				);
 			}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,8 @@
+export interface Options {
+	shouldRemoveDuplicates: boolean;
+	shouldPrependCustomClasses: boolean;
+}
+
 /**
  * Sorts a string of CSS classes according to a predefined order.
  * @param classString The string to sort
@@ -8,27 +13,29 @@
 export const sortClassString = (
 	classString: string,
 	sortOrder: string[],
-	shouldRemoveDuplicates: boolean
+	options: Options
 ): string => {
 	let classArray = classString.split(/\s+/g);
 
-	if (shouldRemoveDuplicates) {
+	if (options.shouldRemoveDuplicates) {
 		classArray = removeDuplicates(classArray);
 	}
 
-	classArray = sortClassArray(classArray, sortOrder);
+	classArray = sortClassArray(classArray, sortOrder, options.shouldPrependCustomClasses);
 
 	return classArray.join(' ');
 };
 
 const sortClassArray = (
 	classArray: string[],
-	sortOrder: string[]
+	sortOrder: string[],
+	shouldPrependCustomClasses: boolean
 ): string[] => [
+	...classArray.filter(el => shouldPrependCustomClasses && sortOrder.indexOf(el) === -1), // append the classes that were not in the sort order if configured this way
 	...classArray
 		.filter(el => sortOrder.indexOf(el) !== -1) // take the classes that are in the sort order
 		.sort((a, b) => sortOrder.indexOf(a) - sortOrder.indexOf(b)), // and sort them
-	...classArray.filter(el => sortOrder.indexOf(el) === -1) // prepend the classes that were not in the sort order
+	...classArray.filter(el => !shouldPrependCustomClasses && sortOrder.indexOf(el) === -1) // prepend the classes that were not in the sort order if configured this way
 ];
 
 const removeDuplicates = (classArray: string[]): string[] => [

--- a/tests/utils.spec.ts
+++ b/tests/utils.spec.ts
@@ -7,13 +7,34 @@ const pjson = require('../package.json');
 const sortOrder: string[] =
 	pjson.contributes.configuration[0].properties['headwind.defaultSortOrder']
 		.default;
+const customClasses: string[] = ['yoda', 'skywalker'];
 
 const randomizedClassString = _.shuffle(sortOrder).join(' ');
+const randomizedClassStringWithCustom = _.shuffle([...sortOrder, ...customClasses]).join(' ');
 
 describe('sortClassString', () => {
 	it('should return a sorted class list string', () => {
-		const result = sortClassString(randomizedClassString, sortOrder, true);
+		const result = sortClassString(randomizedClassString, sortOrder, {
+			shouldRemoveDuplicates: true,
+			shouldPrependCustomClasses: false,
+		});
 		expect(result).toBe(sortOrder.join(' '));
+	});
+
+	it('should return a sorted class list string with appended custom classes', () => {
+		const result = sortClassString(randomizedClassStringWithCustom, sortOrder, {
+			shouldRemoveDuplicates: true,
+			shouldPrependCustomClasses: false,
+		});
+		expect(result).toBe([...sortOrder, ...customClasses].join(' '));
+	});
+
+	it('should return a sorted class list string with prepended custom classes', () => {
+		const result = sortClassString(randomizedClassStringWithCustom, sortOrder, {
+			shouldRemoveDuplicates: true,
+			shouldPrependCustomClasses: true,
+		});
+		expect(result).toBe([...customClasses, ...sortOrder].join(' '));
 	});
 });
 
@@ -25,7 +46,10 @@ describe('removeDuplicates', () => {
 		const result = sortClassString(
 			randomizedAndDuplicatedClassString,
 			sortOrder,
-			true
+			{
+				shouldRemoveDuplicates: true,
+				shouldPrependCustomClasses: false,
+			}
 		);
 		expect(result).toBe(sortOrder.join(' '));
 	});
@@ -37,7 +61,10 @@ describe('removeDuplicates', () => {
 		const result = sortClassString(
 			randomizedAndDuplicatedClassString,
 			sortOrder,
-			false
+			{
+				shouldRemoveDuplicates: false,
+				shouldPrependCustomClasses: false,
+			}
 		);
 		expect(result).toBe(
 			['container', ...sortOrder, 'random', 'random'].join(' ')

--- a/tests/utils.spec.ts
+++ b/tests/utils.spec.ts
@@ -7,10 +7,10 @@ const pjson = require('../package.json');
 const sortOrder: string[] =
 	pjson.contributes.configuration[0].properties['headwind.defaultSortOrder']
 		.default;
-const customClasses: string[] = ['yoda', 'skywalker'];
+const customClass: string = 'yoda';
 
 const randomizedClassString = _.shuffle(sortOrder).join(' ');
-const randomizedClassStringWithCustom = _.shuffle([...sortOrder, ...customClasses]).join(' ');
+const randomizedClassStringWithCustom = _.shuffle([...sortOrder, customClass]).join(' ');
 
 describe('sortClassString', () => {
 	it('should return a sorted class list string', () => {
@@ -26,7 +26,7 @@ describe('sortClassString', () => {
 			shouldRemoveDuplicates: true,
 			shouldPrependCustomClasses: false,
 		});
-		expect(result).toBe([...sortOrder, ...customClasses].join(' '));
+		expect(result).toBe([...sortOrder, customClass].join(' '));
 	});
 
 	it('should return a sorted class list string with prepended custom classes', () => {
@@ -34,7 +34,7 @@ describe('sortClassString', () => {
 			shouldRemoveDuplicates: true,
 			shouldPrependCustomClasses: true,
 		});
-		expect(result).toBe([...customClasses, ...sortOrder].join(' '));
+		expect(result).toBe([customClass, ...sortOrder].join(' '));
 	});
 });
 


### PR DESCRIPTION
I personally prefer having custom classes before all the Tailwind CSS classes.
So I added an additional config flag to allow prepending instead of appending of custom classes.

It's my first time contributing open-source so feel free to give feedback and improvement ideas.