### PR TITLE
Add sortSelection command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "headwind",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "activationEvents": [
         "workspaceContains:**/tailwind.config.js",
         "onCommand:headwind.sortTailwindClasses",
+        "onCommand:headwind.sortSelectedTailwindClasses",
         "onCommand:headwind.sortTailwindClassesOnWorkspace"
     ],
     "main": "./out/extension",
@@ -36,6 +37,10 @@
             {
                 "command": "headwind.sortTailwindClasses",
                 "title": "Headwind: Sort Tailwind CSS Classes"
+            },
+            {
+                "command": "headwind.sortSelectedTailwindClasses",
+                "title": "Headwind: Sort Selected Tailwind CSS Classes"
             },
             {
                 "command": "headwind.sortTailwindClassesOnWorkspace",
@@ -1825,6 +1830,12 @@
                             "typescriptreact": "(?:\\bclassName\\s*=\\s*[\\\"\\']([_a-zA-Z0-9\\s\\-\\:\\/]+)[\\\"\\'])|(?:\\btw\\s*`([_a-zA-Z0-9\\s\\-\\:\\/]*)`)"
                         },
                         "description": "An object with language IDs as keys and their values determining the regex to search for Tailwind CSS classes.",
+                        "scope": "window"
+                    },
+                    "headwind.selectionRegex": {
+                        "type": "string",
+                        "default": "^[_a-zA-Z0-9\\s\\-\\:\\/]+$",
+                        "description": "A string determining the regex to search for Tailwind CSS classes when using the sort selection command.",
                         "scope": "window"
                     },
                     "headwind.runOnSave": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -75,6 +75,36 @@ export function activate(context: ExtensionContext) {
 		}
 	);
 
+	let sortSelection = commands.registerTextEditorCommand(
+		'headwind.sortSelectedTailwindClasses',
+		function (editor, edit) {
+			const selection = editor.selection;
+			const selectedText = editor.document.getText(selection);
+			const selectionRegexStr: string = config.get('headwind.selectionRegex') || ''
+			const selectionRegex = new RegExp(selectionRegexStr)
+			
+			const options = {
+				shouldRemoveDuplicates,
+				shouldPrependCustomClasses,
+				customTailwindPrefix
+			};
+
+
+			if (selectedText.match(selectionRegex)) {
+				edit.replace(
+					selection,
+					sortClassString(
+						selectedText,
+						Array.isArray(sortOrder) ? sortOrder : [],
+						options
+					)
+				);
+			} else {
+				window.showErrorMessage('Headwind Selection Error: Some of your selection doesn\'t look like css classes. Please select only css classes and try again.')
+			}
+		}
+	);
+
 	let runOnProject = commands.registerCommand(
 		'headwind.sortTailwindClassesOnWorkspace',
 		() => {
@@ -112,6 +142,7 @@ export function activate(context: ExtensionContext) {
 
 	context.subscriptions.push(runOnProject);
 	context.subscriptions.push(disposable);
+	context.subscriptions.push(sortSelection);
 
 	// if runOnSave is enabled organize tailwind classes before saving
 	if (config.get('headwind.runOnSave')) {


### PR DESCRIPTION
I thought I would get the ball rolling on #65 because that feature would help me quite a bit, and I imagine others would appreciate it. 

So far, the proposed added command is really simple. 

It uses a regex to make sure the text looks like CSS classes.

Then, if it matches the regex, it sorts the selection. Otherwise, it throws an error message. 

I'm happy to adjust it and/or add documentation if you're interested in adding this feature.

Resolves #65