### PR TITLE
Support Pug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,4 +9,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* Overhauled class detecting regex for javascript/javascriptreact/typescript/typescriptreact, thanks [@petertriho](https://github.com/petertriho) in [#109](https://github.com/heybourn/headwind/pull/109) 
+* Overhauled class detecting regex for javascript/javascriptreact/typescript/typescriptreact, thanks [@petertriho](https://github.com/petertriho) in [#109](https://github.com/heybourn/headwind/pull/109)
+* Support multiple class name regexes per language and optional separator and replacement options, thanks [@han-tyumi](https://github.com/han-tyumi) in [#112](https://github.com/heybourn/headwind/pull/112)

--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ Example from `package.json`:
 ```js
 "headwind.classRegex": {
 		"javascript": [
-        "(?:\\bclass(?:Name)?\\s*=\\s*(?:{([\\w\\d\\s_\\-:/${}()[\\]\"'`,]+)})|([\"'`][\\w\\d\\s_\\-:/]+[\"'`]))|(?:\\btw\\s*(`[\\w\\d\\s_\\-:/]+`))",
-        "(?:[\"'`]([\\w\\d\\s_\\-:/${}()[\\]\"']+)[\"'`])"
-    ],
+				"(?:\\bclass(?:Name)?\\s*=\\s*(?:{([\\w\\d\\s_\\-:/${}()[\\]\"'`,]+)})|([\"'`][\\w\\d\\s_\\-:/]+[\"'`]))|(?:\\btw\\s*(`[\\w\\d\\s_\\-:/]+`))",
+				"(?:[\"'`]([\\w\\d\\s_\\-:/${}()[\\]\"']+)[\"'`])"
+		],
 }
 ```
 
@@ -81,13 +81,13 @@ Example from `package.json`:
 ```js
 "headwind.classRegex": {
 		"jade": [
-        {
-            "regex": "\\.([\\._a-zA-Z0-9\\-]+)",
-            "separator": "\\.",
-            "replacement": "."
-        },
-        "\\bclass\\s*=\\s*[\\\"\\']([_a-zA-Z0-9\\s\\-\\:\\/]+)[\\\"\\']"
-    ],
+				{
+						"regex": "\\.([\\._a-zA-Z0-9\\-]+)",
+						"separator": "\\.",
+						"replacement": "."
+				},
+				"\\bclass\\s*=\\s*[\\\"\\']([_a-zA-Z0-9\\s\\-\\:\\/]+)[\\\"\\']"
+		],
 }
 ```
 
@@ -97,12 +97,12 @@ To debug custom `classRegex`, you can use the code below:
 ```js
 // Your test string here
 const editorText = `
-  export const Layout = ({ children }) => (
-    <div class="h-screen">
-      <div className="w-64 h-full bg-blue-400 relative"></div>
-      <div>{children}</div>
-    </div>
-  )
+	export const Layout = ({ children }) => (
+		<div class="h-screen">
+			<div className="w-64 h-full bg-blue-400 relative"></div>
+			<div>{children}</div>
+		</div>
+	)
 `
 // Your Regex here
 const regex = /(?:\b(?:class|className)?\s*=\s*{?[\"\']([_a-zA-Z0-9\s\-\:/]+)[\"\']}?)/
@@ -110,14 +110,14 @@ const classWrapperRegex = new RegExp(regex, 'gi')
 
 let classWrapper
 while ((classWrapper = classWrapperRegex.exec(editorText)) !== null) {
-  const wrapperMatch = classWrapper[0]
-  const valueMatchIndex = classWrapper.findIndex((match, idx) => idx !== 0 && match)
-  const valueMatch = classWrapper[valueMatchIndex]
+	const wrapperMatch = classWrapper[0]
+	const valueMatchIndex = classWrapper.findIndex((match, idx) => idx !== 0 && match)
+	const valueMatch = classWrapper[valueMatchIndex]
 
-  console.log('classWrapper', classWrapper)
-  console.log('wrapperMatch', wrapperMatch)
-  console.log('valueMatchIndex', valueMatchIndex)
-  console.log('valueMatch', valueMatch)
+	console.log('classWrapper', classWrapper)
+	console.log('wrapperMatch', wrapperMatch)
+	console.log('valueMatchIndex', valueMatchIndex)
+	console.log('valueMatch', valueMatch)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Example from `package.json`:
 
 ```json
 "headwind.classRegex": {
-		"html": "\\bclass\\s*=\\s*[\\\"\\']([_a-zA-Z0-9\\s\\-\\:\\/]+)[\\\"\\']",
-		"javascriptreact": "(?:\\bclassName\\s*=\\s*[\\\"\\']([_a-zA-Z0-9\\s\\-\\:\\/]+)[\\\"\\'])|(?:\\btw\\s*`([_a-zA-Z0-9\\s\\-\\:\\/]*)`)"
+    "html": "\\bclass\\s*=\\s*[\\\"\\']([_a-zA-Z0-9\\s\\-\\:\\/]+)[\\\"\\']",
+    "javascriptreact": "(?:\\bclassName\\s*=\\s*[\\\"\\']([_a-zA-Z0-9\\s\\-\\:\\/]+)[\\\"\\'])|(?:\\btw\\s*`([_a-zA-Z0-9\\s\\-\\:\\/]*)`)"
 }
 ```
 
@@ -57,10 +57,10 @@ Example from `package.json`:
 
 ```js
 "headwind.classRegex": {
-		"javascript": [
-				"(?:\\bclass(?:Name)?\\s*=\\s*(?:{([\\w\\d\\s_\\-:/${}()[\\]\"'`,]+)})|([\"'`][\\w\\d\\s_\\-:/]+[\"'`]))|(?:\\btw\\s*(`[\\w\\d\\s_\\-:/]+`))",
-				"(?:[\"'`]([\\w\\d\\s_\\-:/${}()[\\]\"']+)[\"'`])"
-		],
+    "javascript": [
+        "(?:\\bclass(?:Name)?\\s*=\\s*(?:{([\\w\\d\\s_\\-:/${}()[\\]\"'`,]+)})|([\"'`][\\w\\d\\s_\\-:/]+[\"'`]))|(?:\\btw\\s*(`[\\w\\d\\s_\\-:/]+`))",
+        "(?:[\"'`]([\\w\\d\\s_\\-:/${}()[\\]\"']+)[\"'`])"
+    ],
 }
 ```
 
@@ -80,14 +80,14 @@ Example from `package.json`:
 
 ```js
 "headwind.classRegex": {
-		"jade": [
-				{
-						"regex": "\\.([\\._a-zA-Z0-9\\-]+)",
-						"separator": "\\.",
-						"replacement": "."
-				},
-				"\\bclass\\s*=\\s*[\\\"\\']([_a-zA-Z0-9\\s\\-\\:\\/]+)[\\\"\\']"
-		],
+    "jade": [
+        {
+            "regex": "\\.([\\._a-zA-Z0-9\\-]+)",
+            "separator": "\\.",
+            "replacement": "."
+        },
+        "\\bclass\\s*=\\s*[\\\"\\']([_a-zA-Z0-9\\s\\-\\:\\/]+)[\\\"\\']"
+    ],
 }
 ```
 
@@ -97,12 +97,12 @@ To debug custom `classRegex`, you can use the code below:
 ```js
 // Your test string here
 const editorText = `
-	export const Layout = ({ children }) => (
-		<div class="h-screen">
-			<div className="w-64 h-full bg-blue-400 relative"></div>
-			<div>{children}</div>
-		</div>
-	)
+  export const Layout = ({ children }) => (
+    <div class="h-screen">
+      <div className="w-64 h-full bg-blue-400 relative"></div>
+      <div>{children}</div>
+    </div>
+  )
 `
 // Your Regex here
 const regex = /(?:\b(?:class|className)?\s*=\s*{?[\"\']([_a-zA-Z0-9\s\-\:/]+)[\"\']}?)/
@@ -110,14 +110,14 @@ const classWrapperRegex = new RegExp(regex, 'gi')
 
 let classWrapper
 while ((classWrapper = classWrapperRegex.exec(editorText)) !== null) {
-	const wrapperMatch = classWrapper[0]
-	const valueMatchIndex = classWrapper.findIndex((match, idx) => idx !== 0 && match)
-	const valueMatch = classWrapper[valueMatchIndex]
+  const wrapperMatch = classWrapper[0]
+  const valueMatchIndex = classWrapper.findIndex((match, idx) => idx !== 0 && match)
+  const valueMatch = classWrapper[valueMatchIndex]
 
-	console.log('classWrapper', classWrapper)
-	console.log('wrapperMatch', wrapperMatch)
-	console.log('valueMatchIndex', valueMatchIndex)
-	console.log('valueMatch', valueMatch)
+  console.log('classWrapper', classWrapper)
+  console.log('wrapperMatch', wrapperMatch)
+  console.log('valueMatchIndex', valueMatchIndex)
+  console.log('valueMatch', valueMatch)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,48 @@ Example from `package.json`:
 }
 ```
 
+#### Multi-step Regex
+
+A multi-step regex can be specified by using an array of regexes to be executed in order.
+
+Example from `package.json`:
+
+```js
+"headwind.classRegex": {
+		"javascript": [
+        "(?:\\bclass(?:Name)?\\s*=\\s*(?:{([\\w\\d\\s_\\-:/${}()[\\]\"'`,]+)})|([\"'`][\\w\\d\\s_\\-:/]+[\"'`]))|(?:\\btw\\s*(`[\\w\\d\\s_\\-:/]+`))",
+        "(?:[\"'`]([\\w\\d\\s_\\-:/${}()[\\]\"']+)[\"'`])"
+    ],
+}
+```
+
+The first regex will look for JSX `class` or `className` attributes or [twin.macro](https://github.com/ben-rogerson/twin.macro) usage.
+
+The second regex will then look for class names to be sorted within these matches.
+
+#### Configuration Object
+
+Optionally a configuration object can be passed to specify additional options for sorting class names.
+
+- `regex` - specifies the regex to be used to find class names
+- `separator` - regex pattern that is used to separate class names (default: `"\\s+"`)
+- `replacement` - string used to replace separator matches (default: `" "`)
+
+Example from `package.json`:
+
+```js
+"headwind.classRegex": {
+		"jade": [
+        {
+            "regex": "\\.([\\._a-zA-Z0-9\\-]+)",
+            "separator": "\\.",
+            "replacement": "."
+        },
+        "\\bclass\\s*=\\s*[\\\"\\']([_a-zA-Z0-9\\s\\-\\:\\/]+)[\\\"\\']"
+    ],
+}
+```
+
 #### Debugging Custom Regex:
 
 To debug custom `classRegex`, you can use the code below:

--- a/package.json
+++ b/package.json
@@ -5016,6 +5016,14 @@
                     "headwind.classRegex": {
                         "type": "object",
                         "default": {
+                            "jade": [
+                                {
+                                    "regex": "\\.([\\._a-zA-Z0-9\\-]+)",
+                                    "separator": "\\.",
+                                    "replacement": "."
+                                },
+                                "\\bclass\\s*=\\s*[\\\"\\']([_a-zA-Z0-9\\s\\-\\:\\/]+)[\\\"\\']"
+                            ],
                             "html": "\\bclass\\s*=\\s*[\\\"\\']([_a-zA-Z0-9\\s\\-\\:\\/]+)[\\\"\\']",
                             "css": "\\B@apply\\s+([_a-zA-Z0-9\\s\\-\\:\\/]+);",
                             "javascript": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,13 +5,14 @@ import { sortClassString, getTextMatch, buildMatchers } from './utils';
 import { spawn } from 'child_process';
 import { rustyWindPath } from 'rustywind';
 
-const config = workspace.getConfiguration();
 export type LangConfig =
 	| string
 	| string[]
 	| { regex?: string | string[]; separator?: string; replacement?: string }
 	| undefined;
-const configRegex: { [key: string]: LangConfig | LangConfig[] } =
+
+const config = workspace.getConfiguration();
+const langConfig: { [key: string]: LangConfig | LangConfig[] } =
 	config.get('headwind.classRegex') || {};
 
 const sortOrder = config.get('headwind.defaultSortOrder');
@@ -44,7 +45,7 @@ export function activate(context: ExtensionContext) {
 			const editorLangId = editor.document.languageId;
 
 			const matchers = buildMatchers(
-				configRegex[editorLangId] || configRegex['html']
+				langConfig[editorLangId] || langConfig['html']
 			);
 
 			for (const matcher of matchers) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,12 +1,17 @@
 'use strict';
 
 import { commands, workspace, ExtensionContext, Range, window } from 'vscode';
-import { sortClassString, getTextMatch, buildRegexes } from './utils';
+import { sortClassString, getTextMatch, buildMatchers } from './utils';
 import { spawn } from 'child_process';
 import { rustyWindPath } from 'rustywind';
 
 const config = workspace.getConfiguration();
-const configRegex: { [key: string]: string } =
+export type LangConfig =
+	| string
+	| string[]
+	| { regex?: string | string[]; separator?: string; replacement?: string }
+	| undefined;
+const configRegex: { [key: string]: LangConfig | LangConfig[] } =
 	config.get('headwind.classRegex') || {};
 
 const sortOrder = config.get('headwind.defaultSortOrder');
@@ -38,31 +43,36 @@ export function activate(context: ExtensionContext) {
 			const editorText = editor.document.getText();
 			const editorLangId = editor.document.languageId;
 
-			const regexes = buildRegexes(configRegex[editorLangId] || configRegex['html'])
+			const matchers = buildMatchers(
+				configRegex[editorLangId] || configRegex['html']
+			);
 
-			getTextMatch(regexes, editorText, (text, startPosition) => {
-				const endPosition = startPosition + text.length;
-				const range = new Range(
-					editor.document.positionAt(startPosition),
-					editor.document.positionAt(endPosition)
-				);
+			for (const matcher of matchers) {
+				getTextMatch(matcher.regex, editorText, (text, startPosition) => {
+					const endPosition = startPosition + text.length;
+					const range = new Range(
+						editor.document.positionAt(startPosition),
+						editor.document.positionAt(endPosition)
+					);
 
-				const options = {
-					shouldRemoveDuplicates,
-					shouldPrependCustomClasses,
-					customTailwindPrefix,
-				};
+					const options = {
+						shouldRemoveDuplicates,
+						shouldPrependCustomClasses,
+						customTailwindPrefix,
+						separator: matcher.separator,
+						replacement: matcher.replacement,
+					};
 
-				edit.replace(
-					range,
-					sortClassString(
-						text,
-						Array.isArray(sortOrder) ? sortOrder : [],
-						options
-					)
-				);
-			});
-
+					edit.replace(
+						range,
+						sortClassString(
+							text,
+							Array.isArray(sortOrder) ? sortOrder : [],
+							options
+						)
+					);
+				});
+			}
 		}
 	);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -106,11 +106,16 @@ function buildMatcher(value: LangConfig): Matcher {
 }
 
 export function buildMatchers(value: LangConfig | LangConfig[]): Matcher[] {
-	if (Array.isArray(value) && !isArrayOfStrings(value)) {
-		return value.map((v) => buildMatcher(v));
-	} else {
-		return [buildMatcher(value)];
+	if (value == undefined) {
+		return [];
+	} else if (Array.isArray(value)) {
+		if (!value.length) {
+			return [];
+		} else if (!isArrayOfStrings(value)) {
+			return value.map((v) => buildMatcher(v));
+		}
 	}
+	return [buildMatcher(value)];
 }
 
 export function getTextMatch(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -98,7 +98,7 @@ function buildMatcher(value: LangConfig): Matcher {
 					: [],
 			separator:
 				typeof value.separator === 'string'
-					? new RegExp(value.separator)
+					? new RegExp(value.separator, 'g')
 					: undefined,
 			replacement: value.replacement || value.separator,
 		};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,11 @@
+import { LangConfig } from './extension';
+
 export interface Options {
 	shouldRemoveDuplicates: boolean;
 	shouldPrependCustomClasses: boolean;
 	customTailwindPrefix: string;
+	separator?: RegExp;
+	replacement?: string;
 }
 
 /**
@@ -16,7 +20,7 @@ export const sortClassString = (
 	sortOrder: string[],
 	options: Options
 ): string => {
-	let classArray = classString.split(/\s+/g);
+	let classArray = classString.split(options.separator || /\s+/g);
 
 	if (options.shouldRemoveDuplicates) {
 		classArray = removeDuplicates(classArray);
@@ -36,7 +40,7 @@ export const sortClassString = (
 		options.shouldPrependCustomClasses
 	);
 
-	return classArray.join(' ');
+	return classArray.join(options.replacement || ' ');
 };
 
 const sortClassArray = (
@@ -59,17 +63,53 @@ const removeDuplicates = (classArray: string[]): string[] => [
 	...new Set(classArray),
 ];
 
-function isArrayOfStrings(value: string | string[]): value is string[] {
+function isArrayOfStrings(value: unknown): value is string[] {
 	return (
 		Array.isArray(value) && value.every((item) => typeof item === 'string')
 	);
 }
 
-export function buildRegexes(value: string | string[]): RegExp[] {
-	if (isArrayOfStrings(value)) {
-		return value.map((v) => new RegExp(v, 'gi'));
+export type Matcher = {
+	regex: RegExp[];
+	separator?: RegExp;
+	replacement?: string;
+};
+
+function buildMatcher(value: LangConfig): Matcher {
+	if (typeof value === 'string') {
+		return {
+			regex: [new RegExp(value, 'gi')],
+		};
+	} else if (isArrayOfStrings(value)) {
+		return {
+			regex: value.map((v) => new RegExp(v, 'gi')),
+		};
+	} else if (value == undefined) {
+		return {
+			regex: [],
+		};
 	} else {
-		return [new RegExp(value, 'gi')];
+		return {
+			regex:
+				typeof value.regex === 'string'
+					? [new RegExp(value.regex, 'gi')]
+					: isArrayOfStrings(value.regex)
+					? value.regex.map((v) => new RegExp(v, 'gi'))
+					: [],
+			separator:
+				typeof value.separator === 'string'
+					? new RegExp(value.separator)
+					: undefined,
+			replacement: value.replacement || value.separator,
+		};
+	}
+}
+
+export function buildMatchers(value: LangConfig | LangConfig[]): Matcher[] {
+	if (Array.isArray(value) && !isArrayOfStrings(value)) {
+		return value.map((v) => buildMatcher(v));
+	} else {
+		return [buildMatcher(value)];
 	}
 }
 

--- a/tests/utils.spec.ts
+++ b/tests/utils.spec.ts
@@ -1,7 +1,13 @@
-import { sortClassString, getTextMatch, buildMatchers } from '../src/utils';
+import {
+	sortClassString,
+	getTextMatch,
+	buildMatchers,
+	Matcher,
+} from '../src/utils';
 import 'jest';
 import * as _ from 'lodash';
 import { replace } from 'lodash';
+import { LangConfig } from '../src/extension';
 
 const pjson = require('../package.json');
 
@@ -671,5 +677,132 @@ describe('twin macro - extract tw prop (jsx) string(s) with multiple regexes', (
 				});
 			}
 		}
+	});
+});
+
+describe('buildMatchers', () => {
+	it.only.each<[string, LangConfig | LangConfig[], Matcher[]]>([
+		['undefined', undefined, []],
+		['empty', [], []],
+		[
+			'layered regexes',
+			[
+				'(?:\\bclass(?:Name)?\\s*=\\s*(?:{([\\w\\d\\s_\\-:/${}()[\\]"\'`,]+)})|(["\'`][\\w\\d\\s_\\-:/]+["\'`]))|(?:\\btw\\s*(`[\\w\\d\\s_\\-:/]+`))',
+				'(?:["\'`]([\\w\\d\\s_\\-:/${}()[\\]"\']+)["\'`])',
+			],
+			[
+				{
+					regex: [
+						/(?:\bclass(?:Name)?\s*=\s*(?:{([\w\d\s_\-:/${}()[\]"'`,]+)})|(["'`][\w\d\s_\-:/]+["'`]))|(?:\btw\s*(`[\w\d\s_\-:/]+`))/gi,
+						/(?:["'`]([\w\d\s_\-:/${}()[\]"']+)["'`])/gi,
+					],
+				},
+			],
+		],
+		[
+			'multiple layered regexes',
+			[
+				[
+					'(?:\\bclass(?:Name)?\\s*=\\s*(?:{([\\w\\d\\s_\\-:/${}()[\\]"\'`,]+)})|(["\'`][\\w\\d\\s_\\-:/]+["\'`]))|(?:\\btw\\s*(`[\\w\\d\\s_\\-:/]+`))',
+					'(?:["\'`]([\\w\\d\\s_\\-:/${}()[\\]"\']+)["\'`])',
+				],
+				[
+					'(?:\\bclass(?:Name)?\\s*=\\s*(?:{([\\w\\d\\s_\\-:/${}()[\\]"\'`,]+)})|(["\'`][\\w\\d\\s_\\-:/]+["\'`]))|(?:\\btw\\s*(`[\\w\\d\\s_\\-:/]+`))',
+					'(?:["\'`]([\\w\\d\\s_\\-:/${}()[\\]"\']+)["\'`])',
+				],
+			],
+			[
+				{
+					regex: [
+						/(?:\bclass(?:Name)?\s*=\s*(?:{([\w\d\s_\-:/${}()[\]"'`,]+)})|(["'`][\w\d\s_\-:/]+["'`]))|(?:\btw\s*(`[\w\d\s_\-:/]+`))/gi,
+						/(?:["'`]([\w\d\s_\-:/${}()[\]"']+)["'`])/gi,
+					],
+				},
+				{
+					regex: [
+						/(?:\bclass(?:Name)?\s*=\s*(?:{([\w\d\s_\-:/${}()[\]"'`,]+)})|(["'`][\w\d\s_\-:/]+["'`]))|(?:\btw\s*(`[\w\d\s_\-:/]+`))/gi,
+						/(?:["'`]([\w\d\s_\-:/${}()[\]"']+)["'`])/gi,
+					],
+				},
+			],
+		],
+		[
+			'matcher',
+			{
+				regex: [
+					'(?:\\bclass(?:Name)?\\s*=\\s*(?:{([\\w\\d\\s_\\-:/${}()[\\]"\'`,]+)})|(["\'`][\\w\\d\\s_\\-:/]+["\'`]))|(?:\\btw\\s*(`[\\w\\d\\s_\\-:/]+`))',
+					'(?:["\'`]([\\w\\d\\s_\\-:/${}()[\\]"\']+)["\'`])',
+				],
+				separator: '\\+\\+',
+				replacement: '++',
+			},
+			[
+				{
+					regex: [
+						/(?:\bclass(?:Name)?\s*=\s*(?:{([\w\d\s_\-:/${}()[\]"'`,]+)})|(["'`][\w\d\s_\-:/]+["'`]))|(?:\btw\s*(`[\w\d\s_\-:/]+`))/gi,
+						/(?:["'`]([\w\d\s_\-:/${}()[\]"']+)["'`])/gi,
+					],
+					separator: /\+\+/g,
+					replacement: '++',
+				},
+			],
+		],
+		[
+			'empty matcher',
+			{},
+			[
+				{
+					regex: [],
+					separator: undefined,
+					replacement: undefined,
+				},
+			],
+		],
+		[
+			'various',
+			[
+				[
+					'(?:\\bclass(?:Name)?\\s*=\\s*(?:{([\\w\\d\\s_\\-:/${}()[\\]"\'`,]+)})|(["\'`][\\w\\d\\s_\\-:/]+["\'`]))|(?:\\btw\\s*(`[\\w\\d\\s_\\-:/]+`))',
+				],
+				'(?:["\'`]([\\w\\d\\s_\\-:/${}()[\\]"\']+)["\'`])',
+				{
+					regex: [
+						'(?:\\bclass(?:Name)?\\s*=\\s*(?:{([\\w\\d\\s_\\-:/${}()[\\]"\'`,]+)})|(["\'`][\\w\\d\\s_\\-:/]+["\'`]))|(?:\\btw\\s*(`[\\w\\d\\s_\\-:/]+`))',
+						'(?:["\'`]([\\w\\d\\s_\\-:/${}()[\\]"\']+)["\'`])',
+					],
+					replacement: ' ',
+				},
+				{
+					regex: '(?:["\'`]([\\w\\d\\s_\\-:/${}()[\\]"\']+)["\'`])',
+					separator: '\\.',
+					replacement: '.',
+				},
+			],
+			[
+				{
+					regex: [
+						/(?:\bclass(?:Name)?\s*=\s*(?:{([\w\d\s_\-:/${}()[\]"'`,]+)})|(["'`][\w\d\s_\-:/]+["'`]))|(?:\btw\s*(`[\w\d\s_\-:/]+`))/gi,
+					],
+				},
+				{
+					regex: [/(?:["'`]([\w\d\s_\-:/${}()[\]"']+)["'`])/gi],
+				},
+				{
+					regex: [
+						/(?:\bclass(?:Name)?\s*=\s*(?:{([\w\d\s_\-:/${}()[\]"'`,]+)})|(["'`][\w\d\s_\-:/]+["'`]))|(?:\btw\s*(`[\w\d\s_\-:/]+`))/gi,
+						/(?:["'`]([\w\d\s_\-:/${}()[\]"']+)["'`])/gi,
+					],
+					separator: undefined,
+					replacement: ' ',
+				},
+				{
+					regex: [/(?:["'`]([\w\d\s_\-:/${}()[\]"']+)["'`])/gi],
+					separator: /\./g,
+					replacement: '.',
+				},
+			],
+		],
+	])('should handle %s configs', (_name, langConfig, matchers) => {
+		expect(buildMatchers(langConfig)).toStrictEqual(matchers);
 	});
 });

--- a/tests/utils.spec.ts
+++ b/tests/utils.spec.ts
@@ -4,10 +4,9 @@ import {
 	buildMatchers,
 	Matcher,
 } from '../src/utils';
+import { LangConfig } from '../src/extension';
 import 'jest';
 import * as _ from 'lodash';
-import { replace } from 'lodash';
-import { LangConfig } from '../src/extension';
 
 const pjson = require('../package.json');
 

--- a/tests/utils.spec.ts
+++ b/tests/utils.spec.ts
@@ -1,4 +1,4 @@
-import { sortClassString, getTextMatch, buildRegexes } from '../src/utils';
+import { sortClassString, getTextMatch, buildMatchers } from '../src/utils';
 import 'jest';
 import * as _ from 'lodash';
 
@@ -259,7 +259,9 @@ describe('extract className (jsx) string with single regex', () => {
 			'(?:\\bclass(?:Name)?\\s*=[\\w\\d\\s_,{}()[\\]]*["\'`]([\\w\\d\\s_\\-:/${}]+)["\'`][\\w\\d\\s_,{}()[\\]]*)|(?:\\btw\\s*`([\\w\\d\\s_\\-:/]*)`)';
 		const callback = jest.fn();
 
-		getTextMatch(buildRegexes(stringRegex), editorText.toString(), callback);
+		for (const matcher of buildMatchers(stringRegex)) {
+			getTextMatch(matcher.regex, editorText.toString(), callback);
+		}
 
 		expect(callback).toHaveBeenCalledWith(
 			expectedTextMatch,
@@ -396,11 +398,9 @@ describe('extract className (jsx) string(s) with multiple regexes', () => {
 		for (const jsxLanguage of jsxLanguages) {
 			const callback = jest.fn();
 
-			getTextMatch(
-				buildRegexes(configRegex[jsxLanguage]),
-				editorText.toString(),
-				callback
-			);
+			for (const matcher of buildMatchers(configRegex[jsxLanguage])) {
+				getTextMatch(matcher.regex, editorText.toString(), callback);
+			}
 
 			expect(callback).toHaveBeenCalledWith(
 				expectedTextMatch,
@@ -558,11 +558,9 @@ describe('extract className (jsx) string(s) with multiple regexes', () => {
 		for (const jsxLanguage of jsxLanguages) {
 			const callback = jest.fn();
 
-			getTextMatch(
-				buildRegexes(configRegex[jsxLanguage]),
-				editorText.toString(),
-				callback
-			);
+			for (const matcher of buildMatchers(configRegex[jsxLanguage])) {
+				getTextMatch(matcher.regex, editorText.toString(), callback);
+			}
 
 			expect(callback).toHaveBeenCalledTimes(expectedResults.length);
 			expect(typeof expectedResults !== 'string').toBeTruthy();
@@ -632,11 +630,9 @@ describe('twin macro - extract tw prop (jsx) string(s) with multiple regexes', (
 		for (const jsxLanguage of jsxLanguages) {
 			const callback = jest.fn();
 
-			getTextMatch(
-				buildRegexes(configRegex[jsxLanguage]),
-				editorText.toString(),
-				callback
-			);
+			for (const matcher of buildMatchers(configRegex[jsxLanguage])) {
+				getTextMatch(matcher.regex, editorText.toString(), callback);
+			}
 
 			expect(callback).toHaveBeenCalledTimes(expectedResults.length);
 			expect(typeof expectedResults !== 'string').toBeTruthy();

--- a/tests/utils.spec.ts
+++ b/tests/utils.spec.ts
@@ -1,6 +1,7 @@
 import { sortClassString, getTextMatch, buildMatchers } from '../src/utils';
 import 'jest';
 import * as _ from 'lodash';
+import { replace } from 'lodash';
 
 const pjson = require('../package.json');
 
@@ -42,6 +43,29 @@ describe('sortClassString', () => {
 		});
 		expect(result).toBe([customClass, ...sortOrder].join(' '));
 	});
+
+	it.each<[RegExp | undefined, string | undefined, string]>([
+		[undefined, undefined, ' '],
+		[/\+\+/g, undefined, '++'],
+		[undefined, ',', ' '],
+		[/\./g, '.', '.'],
+	])(
+		'should handle a `%s` class name separator with a `%s` class name separator replacement',
+		(separator, replacement, join) => {
+			const validClasses = sortOrder.filter((c) => !c.includes(join));
+			const randomizedClassString = _.shuffle(validClasses).join(join);
+
+			const result = sortClassString(randomizedClassString, sortOrder, {
+				shouldRemoveDuplicates: true,
+				shouldPrependCustomClasses: false,
+				customTailwindPrefix: '',
+				separator,
+				replacement,
+			});
+
+			expect(result).toBe(validClasses.join(replacement || ' '));
+		}
+	);
 });
 
 describe('removeDuplicates', () => {


### PR DESCRIPTION
Should close out #59.

Added support for
- multiple regexes for a language ID (Pug has 2 forms of writing class names)
- optional `separator` and `replacement` options for a given language regex
  - one of Pug's ways of separating class names is using `.`