### PR TITLE
Support activation for tailwind.config.cjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     ],
     "activationEvents": [
         "workspaceContains:**/tailwind.config.js",
+        "workspaceContains:**/tailwind.config.cjs",
         "onCommand:headwind.sortTailwindClasses",
         "onCommand:headwind.sortTailwindClassesOnWorkspace"
     ],


### PR DESCRIPTION
As issued here #133 

Currently headwind doesnt automatically activate when using ESM file `tailwind.config.cjs`

This PR add activation events for file `tailwind.config.cjs`.