### PR TITLE
fix: CMD+SHIFT+T overriding default vscode shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Overhauled class detecting regex for javascript/javascriptreact/typescript/typescriptreact, thanks [@petertriho](https://github.com/petertriho) in [#109](https://github.com/heybourn/headwind/pull/109)
 * Support multiple class name regexes per language and optional separator and replacement options, thanks [@han-tyumi](https://github.com/han-tyumi) in [#112](https://github.com/heybourn/headwind/pull/112)
+* Fix `cmd+shift+t` overriding default vscode keymap for reopening previously closed tabs, thanks [@tylerjlawson](https://github.com/tylerjlawson) in [#163](https://github.com/heybourn/headwind/pull/163)

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
             {
                 "command": "headwind.sortTailwindClasses",
                 "key": "ctrl+alt+t",
-                "mac": "shift+cmd+t",
+                "mac": "shift+alt+t",
                 "when": "editorFocus"
             }
         ],


### PR DESCRIPTION
will close https://github.com/heybourn/headwind/issues/98