### PR TITLE
Add sorting for modifier classes (`focus:`, `md:`...)

### DIFF
--- a/src/tailwindModifiers.ts
+++ b/src/tailwindModifiers.ts
@@ -1,0 +1,74 @@
+const TAILWIND_PSEUDO_CLASSES = [
+	'hover',
+	'focus',
+	'focus-within',
+	'focus-visible',
+	'active',
+	'visited',
+	'target',
+	'first',
+	'last',
+	'only',
+	'odd',
+	'even',
+	'first-of-type',
+	'last-of-type',
+	'only-of-type',
+	'empty',
+	'disabled',
+	'checked',
+	'indeterminate',
+	'default',
+	'required',
+	'valid',
+	'invalid',
+	'in-range',
+	'out-of-range',
+	'placeholder-shown',
+	'autofill',
+	'read-only'
+]
+
+const TAILWIND_PSEUDO_ELEMENTS = [
+	'before',
+	'after',
+	'placeholder',
+	'file',
+	'marker',
+	'selection',
+	'first-line',
+	'first-letter'
+]
+
+const TAILWIND_RESPONSIVE_BREAKPOINTS = [
+	'sm',
+	'md',
+	'lg',
+	'xl',
+	'2xl'
+]
+
+const TAILWIND_MEDIA_QUERIES = [
+	'dark',
+	'motion-reduce',
+	'motion-safe',
+	'portrait',
+	'landscape',
+	'print'
+]
+
+const TAILWIND_OTHER_MODIFIERS = [
+	'ltr',
+	'rtl',
+	'open'
+]
+
+export const TAILWIND_MODIFIERS = [
+	...TAILWIND_PSEUDO_CLASSES,
+	...TAILWIND_PSEUDO_ELEMENTS,
+	...TAILWIND_RESPONSIVE_BREAKPOINTS,
+	...TAILWIND_MEDIA_QUERIES,
+	...TAILWIND_OTHER_MODIFIERS
+]
+
+export default TAILWIND_MODIFIERS;

--- a/tests/utils.spec.ts
+++ b/tests/utils.spec.ts
@@ -86,6 +86,36 @@ describe('sortClassString', () => {
 			expect(result).toBe(validClasses.join(replacement || ' '));
 		}
 	);
+
+	it('should sort classes with modifiers independently and append those to sorted classes', () => {
+		const result = sortClassString(
+			'xl:mx-6 bg-gray-100 lg:mx-4 mt-1 sm:bg-gray-200 hover:bg-blue-100 lg:bg-gray-400 hover:text-blue-100 xl:bg-gray-600 sm:mx-2',
+			sortOrder,
+			{
+				shouldRemoveDuplicates: true,
+				shouldPrependCustomClasses: false,
+				customTailwindPrefix: '',
+			}
+		);
+		expect(result).toBe(
+			'mt-1 bg-gray-100 hover:text-blue-100 hover:bg-blue-100 sm:mx-2 sm:bg-gray-200 lg:mx-4 lg:bg-gray-400 xl:mx-6 xl:bg-gray-600'
+		);
+	});
+
+	it('should sort classes even if non-modifier classes are after modifier classes (issue #104)', () => {
+		const result = sortClassString(
+			'block w-full px-3 py-2 mb-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm text-blue-gray-500',
+			sortOrder,
+			{
+				shouldRemoveDuplicates: true,
+				shouldPrependCustomClasses: false,
+				customTailwindPrefix: '',
+			}
+		);
+		expect(result).toBe(
+			'block px-3 py-2 mb-2 w-full text-blue-gray-500 bg-white rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 focus:outline-none sm:text-sm'
+		);
+	})
 });
 
 describe('removeDuplicates', () => {
@@ -262,7 +292,7 @@ describe('extract className (jsx) string with single regex', () => {
 								}`),
 			classString,
 			startPosition +
-				`{ clsx(
+			`{ clsx(
 								    foo,
 								    bar,
 								    '`.length,
@@ -285,7 +315,7 @@ describe('extract className (jsx) string with single regex', () => {
 								  }`),
 			classString,
 			startPosition +
-				`{ clsx(
+			`{ clsx(
 									  foo,
 									  bar,
 									  "`.length,


### PR DESCRIPTION
Hey everyone! This PR adds sorting for Tailwind modifier classes: `md:w-12`,`hover:bg-gray-500`...

The sort is as follows:
- Modifier classes are added after non-modifier classes, but before
  customClasses if those are appended
- For a given modifier (e.g. `md:`), the sort is the same as `sortOrder`
- Modifiers are sorted among one another in the order they appear in the
  Tailwind documentation.

This PR does not introduce all possible variations of all possible classes, but instead does the following:

- Get all classes with any modifier
- Split them out in one array per modifier
- Sort those individual arrays using `sortOrder`
- Flatten all the individual arrays

Example:

```javascript
// Input:
"xl:mx-6 bg-gray-100 lg:mx-4 mt-1 sm:bg-gray-200 hover:bg-blue-100 lg:bg-gray-400 hover:text-blue-100 xl:bg-gray-600 sm:mx-2"

// Output:
"mt-1 bg-gray-100 hover:text-blue-100 hover:bg-blue-100 sm:mx-2 sm:bg-gray-200 lg:mx-4 lg:bg-gray-400 xl:mx-6 xl:bg-gray-600"
```

Closes #52, #104 and #142.

I’m not sure whether we should make the order of modifier classes, or modified vs. non-modified classes customizable. I’d suggest tackling this in a subsequent PR should we want to!