### PR TITLE
docs: Added a link to the default settings for headwind.defaultSortOrder

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Good example value: `valueMatch w-64 h-full bg-blue-400 relative`
 ### `headwind.defaultSortOrder`:
 
 An array that determines Headwind's default sort order.
+Please find the default settings in [package.json](https://github.com/heybourn/headwind/blob/master/package.json).
 
 ### `headwind.removeDuplicates`:
 


### PR DESCRIPTION
As a user, I'd like to be able to look at the default sort order which the package provides out of the box but the location of this setting is not obvious for me.