### PR TITLE
Fix default option values

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ An array that determines Headwind's default sort order.
 
 Headwind will remove duplicate class names by default. This can be toggled on or off.
 
-`"headwind.removeDuplicates": false`
+`"headwind.removeDuplicates": true`
 
 ### `headwind.prependCustomClasses`:
 
@@ -149,7 +149,7 @@ Headwind will append custom class names by default. They can be prepended instea
 
 Headwind will run on save by default (if a `tailwind.config.js` file is present within your working directory). This can be toggled on or off.
 
-`"headwind.runOnSave": false`
+`"headwind.runOnSave": true`
 
 ## Contributing
 


### PR DESCRIPTION
Hi there 👋 First of all, thanks for Headwind, really cool! Seems like [Headwind provides the missing space elimination feature from the official `prettier-plugin-tailwindcss`](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/issues/71#issuecomment-1656725927), so I'll have to give it a shot soon.

This PR corrects the default values that are in the readme to be consistent with the paragraphs above ("Headwind will ... by default")

This will also require publishing to update the readme on [the Visual Studio Marketplace page](https://marketplace.visualstudio.com/items?itemName=heybourn.headwind)